### PR TITLE
Create ssh temp files in /tmp

### DIFF
--- a/bsync
+++ b/bsync
@@ -98,7 +98,7 @@ def printerr(s):
 
 def ssh_master_init(ssh):
 	import tempfile, atexit
-	tmpdir = tempfile.mkdtemp()
+	tmpdir = tempfile.mkdtemp(dir="/tmp")
 	ssh.sock = os.path.join(tmpdir, "bsync_%r@%h:%p")
 	try:
 		subprocess.check_call( ssh.getcmdlist()+["-fNM"] )


### PR DESCRIPTION
On MacOS Ventura (and possibly other versions), bsync would error out with an error:

```
unix_listener: path "/var/folders/14/wm3lnzbj1wn7df44pvjzk0jr0000gn/T/tmpqq7gvk9z/bsync_XXXXX@XXXXXX.XXXX.XXXXXXXX.XXX:22.4zVXxKvPKKgMLu6r" too long for Unix domain socket
Error: could not open SSH connection.
```

This patch moves the created directory in to /tmp (from /var/folders/...gn/T/ in the above example) which gets the path under the character limit.

Using `%C` as suggested on https://gist.github.com/andyvanee/bcf95b1044b80e72b4a42933549a079b didn't work, the path was still too long.