### PR TITLE
Add wildcard support to .bsync-ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Say, if I have a `dir1/.bsync-ignore` file with content:
 
 `dir1/path/to/ignoredir` (+content) and `dir1/path/to/ignorefile` will be ignored in the next bsync runs.
 
-The ignore file has to be very simple. No comments, just path prefixes.
+The ignore file has to be very simple. Lines that start with `#` are comments and are ignored.
 
 ### See also
 

--- a/README.md
+++ b/README.md
@@ -118,8 +118,35 @@ A sample run with a conflict: file deleted one side and updated the other side.
 .bsync-ignore files
 -------------------
 
-You can add directories/files paths in a `.bsync-ignore` file located at the root of a sync directory.
-Every path in it will be ignored when syncing with other dirs. You can also see that as a mask for the synchronization.
+You can add directories/file paths in a `.bsync-ignore` file located at the root of a sync directory.
+It uses Unix-style pattern matching:
+
+| Pattern | Meaning                          |
+|---------|----------------------------------|
+| *       | matches everything               |
+| ?       | matches any single character     |
+| [seq]   | matches any character in seq     |
+| [!seq]  | matches any character not in seq |
+
+For example:
+```
+# Ignore a directory and all its contents
+path/to/ignoredir/
+
+# Ignore a specific file
+path/to/ignorefile
+
+# Ignore a file with a specific name in any direcotory
+*.DS_Store 
+
+# Ignore certain files in any directory under a specific path
+path/*/.DS_Store
+
+# Ignore a file in any directory EXCEPT the root
+*/.DS_Store
+```
+
+You can also see that as a mask for the synchronization.
 
 Say, if I have a `dir1/.bsync-ignore` file with content:
 

--- a/bsync
+++ b/bsync
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os, sys, shutil, subprocess, collections, time, datetime, shlex, getopt, stat
+import os, sys, shutil, subprocess, collections, time, datetime, shlex, getopt, stat, fnmatch
 
 # from python3.3 tree: Lib/shlex.py (shlex.quote not in python3.2)
 import re
@@ -302,9 +302,9 @@ def get_ignores(ignorefile, ssh,dirname):
 	ignores = set()
 	for l in lines:
 		if l != "" and not l.strip().startswith("#"):
-			if not l.endswith("/"): l+="/"
-			ignores.add(l)
+			ignores.add(str.encode(l))
 	return ignores
+
 
 # returns True if the path has to be ignored
 # ignore root path and .bsync files
@@ -313,7 +313,7 @@ def ignorepath(path, ignoreset):
 		return True
 	else:
 		for ignore in ignoreset:
-			if (path+b"/").startswith(ignore.encode()):
+			if fnmatch.fnmatchcase(path, ignore):
 				return True
 	return False
 

--- a/bsync
+++ b/bsync
@@ -301,7 +301,7 @@ def get_ignores(ignorefile, ssh,dirname):
 
 	ignores = set()
 	for l in lines:
-		if l != "":
+		if l != "" and not l.strip().startswith("#"):
 			if not l.endswith("/"): l+="/"
 			ignores.add(l)
 	return ignores

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -146,6 +146,31 @@ test_exotic_filename_ssh() {
 	ssh $sshargs $SSHLOGIN "find $SSHDIR | grep exotic:"
 }
 
+test_ignore_files() {
+	echo "**test_ignore_files**"
+  mkdir $DIR1/ignore
+  touch $DIR1/ignore/afile
+  touch $DIR1/ignore/exactfile
+  touch $DIR1/ignore/otherfile
+  mkdir $DIR1/ignore2
+  touch $DIR1/ignore2/otherfile
+  echo '# Ignore files named otherfile no matter what directory they are in' > $DIR1/.bsync-ignore
+  echo '**/otherfile' >> $DIR1/.bsync-ignore
+  echo '# Ignore exact file match (old style matches)' >> $DIR1/.bsync-ignore
+  echo 'ignore/exactfile' >> $DIR1/.bsync-ignore
+	yes | $BSYNC $DIR1 $DIR2
+	[ ! -f $DIR2/ignore/otherfile ]
+	[ ! -f $DIR2/ignore/exactfile ]
+	[ ! -f $DIR2/ignore2/otherfile ]
+  [ -f $DIR2/ignore/afile ]
+  rm -f $DIR1/.bsync-ignore
+  rm -rf $DIR1/ignore/
+  rm -rf $DIR1/ignore2/
+	rm -rf $DIR2/ignore/
+	rm -rf $DIR2/ignore2/
+}
+
+
 ########
 
 test_no_args
@@ -176,6 +201,7 @@ test_non_interactive
 test_non_interactive_exit
 
 test_symlinks
+test_ignore_files
 
 test_ssh_fail_noremotedir
 


### PR DESCRIPTION
Adds comment and wildcard support to the `.bsync-ignore` file. Wildcard support is via [fnmatch](https://docs.python.org/3/library/fnmatch.html)

The current format of .bsync-ignore should still work as well, but please double check the test I added.

I've been using this for a few weeks on both MacOS and Fedora Linux and it's been working as expected.